### PR TITLE
Fix lodewallet url

### DIFF
--- a/docs/Wallets/list.md
+++ b/docs/Wallets/list.md
@@ -40,4 +40,4 @@ Note that in case of issues, usually only queries relating to official wallets c
 [Atomic]: https://atomicwallet.io/
 [Gero]: https://gerowallet.io
 [Exodus]: https://www.exodus.io/
-[LodeWallet]: https://www.lodewallet.io
+[LodeWallet]: https://lodewallet.io


### PR DESCRIPTION
## Description
The url for lodewallet's webpage should not have a www.

## Motivation and context
The link at current is broken.

## How has this been tested?
Clicked the hyperlink in the markdown and verified it opened the webpage.
