### PR TITLE
Jimmy lee16 update yoroi wallet url

### DIFF
--- a/docs/Wallets/list.md
+++ b/docs/Wallets/list.md
@@ -34,7 +34,7 @@ Note that in case of issues, usually only queries relating to official wallets c
 
 [1]: types.md#software-wallets
 [Daedalus]: https://daedaluswallet.io
-[Yoroi]: https://yoroi-wallet.com
+[Yoroi]: https://yoroiwallet.com
 [ADAlite]: https://www.adalite.io
 [NuFi]: https://nu.fi
 [Typhon]: https://typhonwallet.io


### PR DESCRIPTION
## Description
Updated the Yoroi wallet reference link in `support-faq/docs/Wallets/list.md`.  
- Old link: https://yoroi-wallet.com (flagged as phishing)  
- New official link: https://yoroiwallet.com 
## Which issue it fixes?
N/A