### PR TITLE
Add Vultisig to wallet list

### DIFF
--- a/docs/Wallets/list.md
+++ b/docs/Wallets/list.md
@@ -1,5 +1,5 @@
 
-Well-known and actively maintained wallets supporting the Cardano Blockchain are [Eternl], [Typhon], [Vespr], [Lace], [ADAlite], [NuFi], [Daedalus], [Gero], [LodeWallet], [Coin Wallet], [ADAWallet], [Atomic], [Gem Wallet], [Trust], [Exodus] and [SecondFi].
+Well-known and actively maintained wallets supporting the Cardano Blockchain are [Eternl], [Typhon], [Vespr], [Lace], [ADAlite], [NuFi], [Daedalus], [Gero], [LodeWallet], [Coin Wallet], [ADAWallet], [Atomic], [Gem Wallet], [Trust], [Exodus], [SecondFi] and [Vultisig].
 
 Note that in case of issues, usually only queries relating to official wallets can be answered in Cardano groups across telegram/forum. You may need to consult with specific wallet support teams for third party wallets.
 
@@ -28,6 +28,7 @@ Note that in case of issues, usually only queries relating to official wallets c
 | [Coin Wallet] | Light     | 6     | :ballot_box_with_check: | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                       | :ballot_box_with_check: | ( :ballot_box_with_check:,:x:,:ballot_box_with_check: ) | [:ballot_box_with_check:](https://github.com/CoinSpace/CoinSpace)      |
 | [Atomic]      | Light     | 6     | :ballot_box_with_check: | :ballot_box_with_check: | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                       | :ballot_box_with_check: | ( :ballot_box_with_check:,:x:,:ballot_box_with_check: ) | :x:                                                                    |
 | [Gem Wallet]  | Light     | 6     | :ballot_box_with_check: | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :ballot_box_with_check: | :x:                       | :ballot_box_with_check: | ( :x:,:x:,:x: )                                         | :ballot_box_with_check:                                                |
+| [Vultisig]    | Light     | 5     | :ballot_box_with_check: | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                       | :ballot_box_with_check: | ( :ballot_box_with_check:,:x:,:x: )                     | [Partial](https://github.com/vultisig)                                 |
 | [Trust]       | Light     | 4     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :ballot_box_with_check: | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                       | :ballot_box_with_check: | ( :x:,:x:,:ballot_box_with_check: )                     | :x:                                                                    |
 | [Exodus]      | Light     | 2     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                     | :x:                       | :ballot_box_with_check: | ( :x:,:x:,:ballot_box_with_check: )                     | :x:                                                                    |
 
@@ -48,6 +49,7 @@ Note that in case of issues, usually only queries relating to official wallets c
 [Vespr]: https://vespr.xyz
 [Gem Wallet]: https://gemwallet.com
 [SecondFi]: https://secondfi.io
+[Vultisig]: https://vultisig.com
 
 
 ### Brief info on fields above


### PR DESCRIPTION
Adds Vultisig to the wallet comparison table (score 5, placed between Gem Wallet and Trust). Per-column justification, following the Vespr PR's format — I work for Vultisig, so over-explaining the judgment cells:

- **Type: Light** — not a Cardano full node.
- **Score: 5** — computed with the table's convention (1/check across feature columns, +1 desktop-any, +1 full open-source).
- **Non-Custodial: ✓** — no complete private key ever exists anywhere: keys are generated as MPC/TSS shares on the user's own devices, and signing requires a threshold of them. In Secure Vaults (2-of-3+) Vultisig holds no share at all. The optional Fast Vault (2-of-2) keeps one share on a Vultisig co-signing server for convenience — that share is below threshold and cannot sign or move funds by itself, and users can upgrade to fully self-held vaults. The provider can never move user funds.
- **Compatibility: ✗** — no BIP39 mnemonic; vaults are not restorable in other wallets (backups are encrypted vault-share files, re-importable into Vultisig).
- **Stake Control: ✗** — enterprise address, no stake component, no delegation.
- **Transparent Support: ✓** — public Discord with non-anonymous team members: https://discord.gg/thq64eaYVN
- **Voting: ✗** — no Catalyst/governance.
- **Hardware Wallet: ✗** · **Native Assets: ✗** · **dApp Integration: ✗** (no CIP-30) · **Testnets: ✗** · **Custom Backend: ✗** · **Single/Multi Address: ✗** (single enterprise address per vault).
- **Stability: ✓** — no reports of missing-balance/out-of-sync backend issues.
- **Mobile: ✓** (iOS + Android) · **Desktop: (✓,✗,✗)** — native desktop app for Windows/macOS/Linux; the browser extension does not serve Cardano dApps so it is not claimed; no web wallet.
- **Open Source: [Partial](https://github.com/vultisig)** — all wallet applications are Apache-2.0; scored 0 per tip 12 since not every backend component is independently runnable.

## receipts

no runtime changes

Markdown-only. Column count verified identical across all rows; score recomputed with the same formula that reproduces every existing row's score (validated 16/16); row placed per descending-score sort.